### PR TITLE
only log properties that are safe to log

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -95,7 +95,12 @@ public class BasicSimianArmyContext implements Monkey.Context {
         }
         LOGGER.info("The following are properties in the context.");
         for (Entry<Object, Object> prop : properties.entrySet()) {
-            LOGGER.info(String.format("%s = %s", prop.getKey(), prop.getValue()));
+            Object propertyKey = prop.getKey();
+            if (isSafeToLog(propertyKey)) {
+                LOGGER.info(String.format("%s = %s", propertyKey, prop.getValue()));
+            } else {
+                LOGGER.info(String.format("%s = (not shown here)", propertyKey));
+            }
         }
 
         config = new BasicConfiguration(properties);
@@ -121,6 +126,18 @@ public class BasicSimianArmyContext implements Monkey.Context {
 
         createRecorder();
 
+    }
+
+    /**
+     * Checks whether it is safe to log the property based on the given
+     * property key.
+     * @param propertyKey The key for the property, expected to be resolvable to a String
+     * @return A boolean indicating whether it is safe to log the corresponding property
+     */
+    protected boolean isSafeToLog(Object propertyKey) {
+        String propertyKeyName = propertyKey.toString();
+        return !propertyKeyName.contains("secretKey")
+                && !propertyKeyName.contains("vsphere.password");
     }
 
     /** loads the given config on top of the config read by previous calls. */

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicContext.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicContext.java
@@ -38,4 +38,22 @@ public class TestBasicContext {
         // Verify that the property in chaos.properties overrides the same property in simianarmy.properties
         Assert.assertFalse(ctx.configuration().getBool("simianarmy.chaos.enabled"));
     }
+
+    @Test
+    public void testIsSafeToLogProperty() {
+        BasicChaosMonkeyContext ctx = new BasicChaosMonkeyContext();
+        Assert.assertTrue(ctx.isSafeToLog("simianarmy.client.aws.region"));
+    }
+
+    @Test
+    public void testIsNotSafeToLogProperty() {
+        BasicChaosMonkeyContext ctx = new BasicChaosMonkeyContext();
+        Assert.assertFalse(ctx.isSafeToLog("simianarmy.client.aws.secretKey"));
+    }
+
+    @Test
+    public void testIsNotSafeToLogVsphereProperty() {
+        BasicChaosMonkeyContext ctx = new BasicChaosMonkeyContext();
+        Assert.assertFalse(ctx.isSafeToLog("simianarmy.client.vsphere.password"));
+    }
 }


### PR DESCRIPTION
Currently the context logs all key/value pairs from the configuration. This also includes the AWS secret key. Writing the AWS secret key to the log file makes the log file security-critical, something we would like to avoid.